### PR TITLE
Fix mis-rendered links

### DIFF
--- a/docs/build/introduction.md
+++ b/docs/build/introduction.md
@@ -28,7 +28,7 @@ Build your best ideas with us
 <PageRef url="https://pact-language.readthedocs.io/en/stable/" pageName="ReadtheDocs" />
 <PageRef url="/learn-pact/intro" pageName="Developer tutorials" />
 <PageRef url="https://github.com/kadena-io/pact" pageName="Pact on GitHub" />
-[Install Pact on Atom](/learn-pact/beginner/atom-sdk)
+<PageRef url="/learn-pact/beginner/atom-sdk" pageName="Install Pact on Atom" />
 <PageRef url="https://github.com/kadena-io/developer-scripts" pageName="Code samples" />
 <PageRef url="https://medium.com/kadena-io/safer-smarter-contracts-with-pact-e86b9ccaca9f" pageName="Articles" />
 
@@ -47,7 +47,8 @@ Build your best ideas with us
 <PageRef url="https://github.com/kadena-io/chainweaver/releases" pageName="Chainnweaver Liunx" />
 <PageRef url="https://github.com/kadena-io/chainweaver/releases" pageName="Chainweaver Windows" />
 <PageRef url="../../../basics/chainweaver/chainweaver-user-guide" pageName="Chainweaver user guide" />
-[Atom IDE](/learn-pact/beginner/atom-sdk)
+
+<PageRef url="/learn-pact/beginner/atom-sdk" pageName="Atom IDE" />
 <PageRef url="https://explorer.chainweb.com/mainnet" pageName="Block explorer" />
 <PageRef url="https://transfer.chainweb.com/" pageName="Web transfer tools" />
 <PageRef url="https://balance.chainweb.com/" pageName="Balance checker" />


### PR DESCRIPTION
Some links were misrendered, displaying markdown instead, like so:

![snap-broken-link](https://user-images.githubusercontent.com/115649719/195389213-2d27da5a-cbd4-40b9-bcf3-1df828ec2470.png)

Simple fix ✌️