### PR TITLE
PageRef component fixes & improvements:

### DIFF
--- a/src/components/PageRef.module.css
+++ b/src/components/PageRef.module.css
@@ -30,7 +30,7 @@
 }
 
 .url {
-  justify-self: end;
+  text-align: right;
   color: var(--ifm-color-secondary-darkest);
   font-size: 12px;
 }

--- a/src/components/PageRef.tsx
+++ b/src/components/PageRef.tsx
@@ -4,9 +4,48 @@ import styles from './PageRef.module.css';
 type PageRefProps = {
   url: string,
   pageName: string,
+  maxUrlLength?: number,
 }
 
-export default function PageRef({ url, pageName } : PageRefProps) {
+const schemeRegex = /https?:\/\//;
+
+/*
+ * Strip URI scheme (http) and www.
+ * e.g. `https://www.youtube.com/play` -> `//youtube.com/play`
+ */
+function stripUriScheme(url: string) {
+  if (schemeRegex.test(url)) {
+    const strippedScheme = url.slice(url.indexOf(':') + 1);
+    if (strippedScheme.startsWith('//www.')) {
+      return `//${strippedScheme.slice(6)}`;
+    }
+    return strippedScheme;
+  }
+  return url;
+}
+
+const upDirRegex = /^(\.\.\/)+/;
+
+/*
+ * Prettify URL for display
+ * - strip scheme, www. subdomain
+ * - strip ../../ prefix
+ * - enforce max length
+ */
+function prettyUrl(url: string, maxUrlLength: number): string {
+  let strippedUrl = stripUriScheme(url);
+  // remove leading ../../
+  while(upDirRegex.test(strippedUrl)) {
+    strippedUrl = strippedUrl.replace(upDirRegex, '/');
+  }
+  // enforce max length
+  if (strippedUrl.length > maxUrlLength) {
+    return `${strippedUrl.slice(0, maxUrlLength)}...`;
+  }
+  return strippedUrl;
+}
+
+export default function PageRef({ url, pageName, maxUrlLength=48 } : PageRefProps) {
   return (
     <a
       className={styles.pageRef}
@@ -16,7 +55,7 @@ export default function PageRef({ url, pageName } : PageRefProps) {
         <div className={styles.arrow}>&#8594;</div>
         <div className={styles.pageName}>{pageName}</div>
       </div>
-      <div className={styles.url}>{url}</div>
+      <div className={styles.url}>{prettyUrl(url, maxUrlLength)}</div>
     </a>
   )
 }


### PR DESCRIPTION
Fixed some styling issues with the PageRef component, especially in small screens. Somewhat subjective but I think it is an improvement.

- Fixed: url text did not align right when line wrapped
- Improvement?: stripped uri scheme & www. subdomain from absolute urls
- Improvement?: limit max url length
- Improvement?: replace leading ../ recursively with /

[Before](https://docs.kadena.io/build/introduction):

![1665646261](https://user-images.githubusercontent.com/115649719/195553085-3a68650d-9ab4-46d7-806a-10cd389f012b.png)

[After - preview:](https://deploy-preview-73--festive-swartz-adea72.netlify.app/build/introduction)

![1665646257](https://user-images.githubusercontent.com/115649719/195553195-03662f74-4068-46e3-bb5f-b5adb7fe8812.png)
