### PR TITLE
Fix typos and adjust section heirarchy

### DIFF
--- a/docs/basics/chainweaver/chainweaver-user-guide.md
+++ b/docs/basics/chainweaver/chainweaver-user-guide.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 ## **Getting Started** <a href="#chainweaver-user-guide" id="chainweaver-user-guide"></a>
 
-#### Installing the Chainweaver software <a href="#installing-the-chainweaver-software" id="installing-the-chainweaver-software"></a>
+### Installing the Chainweaver software <a href="#installing-the-chainweaver-software" id="installing-the-chainweaver-software"></a>
 
 Chainweaver is available for download in three formats to accommodate users’ preference in operating system; (1) .dmg for Mac, (2) .deb for Linux, (3) and .ova for Windows, Linux, and Mac as a virtual appliance
 
@@ -104,7 +104,7 @@ See the [Chainweaver Troubleshoot ](chainweaver-troubleshooting.md)page if you e
 
 :::
 
-#### Create a new wallet or restore an existing wallet <a href="#create-a-new-wallet-or-restore-an-existing-wallet" id="create-a-new-wallet-or-restore-an-existing-wallet"></a>
+### Create a new wallet or restore an existing wallet <a href="#create-a-new-wallet-or-restore-an-existing-wallet" id="create-a-new-wallet-or-restore-an-existing-wallet"></a>
 
 ![create-a-new](https://kadena-io.github.io/kadena-docs/assets/Chainweaver/create-a-new.png)
 

--- a/docs/basics/chainweaver/chainweaver-user-guide.md
+++ b/docs/basics/chainweaver/chainweaver-user-guide.md
@@ -222,6 +222,12 @@ Summarily, keysets look like the following as JSON data:
 
 When signing a transaction, the list of private keys supplied as signing key pairs will be checked against the keyset and predicate to ensure that not only are all keys that need to be present accounted for but also that the predicate is satisfied.
 
+:::note Help
+
+Learn more about Keys and Accounts in [this guide](https://medium.com/kadena-io/beginners-guide-to-kadena-accounts-keysets-fb7f32104291) for beginners.
+
+:::
+
 ## Generate a Key <a href="#generate-a-key" id="generate-a-key"></a>
 
 The first step towards transacting on the Kadena blockchain is to generate a key pair. Chainweaver automatically generates your first key.

--- a/docs/build/introduction.md
+++ b/docs/build/introduction.md
@@ -25,7 +25,7 @@ Build your best ideas with us
 
 ### Pact
 
-<PageRef url="https://pact-language.readthedocs.io/en/stable/" pageName="ReadtheDocs" />
+<PageRef url="https://pact-language.readthedocs.io/en/stable/" pageName="Read the Docs" />
 <PageRef url="/learn-pact/intro" pageName="Developer tutorials" />
 <PageRef url="https://github.com/kadena-io/pact" pageName="Pact on GitHub" />
 <PageRef url="/learn-pact/beginner/atom-sdk" pageName="Install Pact on Atom" />

--- a/docs/build/introduction.md
+++ b/docs/build/introduction.md
@@ -42,9 +42,9 @@ Build your best ideas with us
 
 ## Tools
 
-<PageRef url="https://github.com/kadena-io/chainweaver" pageName="Chaineweaver (wallet & workbench)" />
+<PageRef url="https://github.com/kadena-io/chainweaver" pageName="Chainweaver (wallet & workbench)" />
 <PageRef url="https://github.com/kadena-io/chainweaver/releases" pageName="Chainweaver macOS" />
-<PageRef url="https://github.com/kadena-io/chainweaver/releases" pageName="Chainnweaver Liunx" />
+<PageRef url="https://github.com/kadena-io/chainweaver/releases" pageName="Chainweaver Linux" />
 <PageRef url="https://github.com/kadena-io/chainweaver/releases" pageName="Chainweaver Windows" />
 <PageRef url="../../../basics/chainweaver/chainweaver-user-guide" pageName="Chainweaver user guide" />
 

--- a/docs/contribute/node/overview.md
+++ b/docs/contribute/node/overview.md
@@ -15,13 +15,13 @@ import TabItem from '@theme/TabItem';
 - [chainweb-node](https://github.com/kadena-io/chainweb-node): The complete open-source repository for Chainweb
 - [Chainweb binaries](https://github.com/kadena-io/chainweb-node/releases): The latest binary release to run your own node
 - [Bootstrap nodes](https://github.com/kadena-io/chainweb-node#bootstrap-nodes): A list of bootstrap nodes for Mainnet and Testnet
-- [Hardware specs required to run a node](https://github.com/kadena-io/chainweb-node#installing-chainweb-node): Kadena official README
+- [Hardware specs required to run a node](https://github.com/kadena-io/chainweb-node#installing-chainweb-node): Kadena's official README
 - [Troubleshooting](https://kadena-io.github.io/kadena-docs/troubleshoot-chainweb): Common issues related to running a node
 
 **Guides**
 
-- [Installing Chainweb](https://github.com/kadena-io/chainweb-node#installing-chainweb) (Mac and Linux): Kadena official README
-- [Configuring and running a node](https://github.com/kadena-io/chainweb-node#configuration): Kadena official README
+- [Installing Chainweb](https://github.com/kadena-io/chainweb-node#installing-chainweb) (Mac and Linux): Kadena's official README
+- [Configuring and running a node](https://github.com/kadena-io/chainweb-node#configuration): Kadena's official README
 - [Running a node, alternate 1](https://github.com/kadena-community/node-setup): Kadena node installation instructions (Community contribution)
 - [Running a node, alternate 2](https://medium.com/kadenacoin/how-to-operate-a-kadena-node-kda-7844622ed5b4): Kadena node installation instructions (Community contribution)
-- [Monitoring the health of a node](https://github.com/kadena-io/chainweb-node#monitoring-the-health-of-a-chainweb-node): Kadena official README
+- [Monitoring the health of a node](https://github.com/kadena-io/chainweb-node#monitoring-the-health-of-a-chainweb-node): Kadena's official README


### PR DESCRIPTION
- Adjusted the heading level of Installation and creating a new wallet in the Chainweaver user guide so those sections show up in the side bar shortcuts
- Added note section that links to the Beginner's guide to Accounts and Keys because I felt like it would have been helpful to read it at that point