### PR TITLE
Fix for broken links

### DIFF
--- a/docs/basics/chainweaver/chainweaver-user-guide.md
+++ b/docs/basics/chainweaver/chainweaver-user-guide.md
@@ -458,7 +458,7 @@ If you have a request key from a previously submitted transaction, you can also 
 
 The ability to write, deploy, and call smart contracts from within Chainweaver makes it one of the most comprehensive workbench tools for blockchain. Navigate to the Contracts section and utilize the integrated development environment (IDE) for developing and testing Pact smart contracts.
 
-Pact is the safe and simple smart contract language used for interacting with the Kadena blockchain. Visit [learn pact](https://docs.kadena.io/learn-pact/intro) for developer tutorials covering key concepts and real projects you can deploy yourself.
+Pact is the safe and simple smart contract language used for interacting with the Kadena blockchain. Visit [learn pact](/learn-pact/intro) for developer tutorials covering key concepts and real projects you can deploy yourself.
 
 ## Deploy your own smart contract <a href="#deploy-your-own-smart-contract" id="deploy-your-own-smart-contract"></a>
 

--- a/docs/basics/faq.md
+++ b/docs/basics/faq.md
@@ -78,4 +78,4 @@ Official information for running a node is maintained at [this GitHub repository
 
 ### **How do I become a miner?**
 
-Official information for mining KDA is maintained at [this GitHub repository](https://github.com/kadena-io/chainweb-miner), and supplementary resources here.
+Official information for mining KDA is maintained at [this GitHub repository](https://github.com/kadena-io/chainweb-mining-client), and supplementary resources here.

--- a/docs/basics/kda/what-is-kda.md
+++ b/docs/basics/kda/what-is-kda.md
@@ -37,4 +37,4 @@ Current circulating supply can be found on the [Kadena Block Explorer](https://e
 
 ## How do I get KDA?
 
-Resources and guides for securing, managing and moving KDA are available [here](https://docs.kadena.io/basics/kda/manage-kda).
+Resources and guides for securing, managing and moving KDA are available [here](/basics/kda/manage-kda).

--- a/docs/basics/quickstart.md
+++ b/docs/basics/quickstart.md
@@ -155,4 +155,4 @@ Learn Pact, Kadena’s human-readable smart contract language
 
 Already have a dApp idea? Apply to our Developer Program to get technical and marketing support from Kadena.
 
-- [Go to Developer Program](https://kadena.io/developerprogram)
+- [Go to Developer Program](https://docs.kadena.io/basics/support/developer-program)

--- a/docs/basics/quickstart.md
+++ b/docs/basics/quickstart.md
@@ -155,4 +155,4 @@ Learn Pact, Kadena’s human-readable smart contract language
 
 Already have a dApp idea? Apply to our Developer Program to get technical and marketing support from Kadena.
 
-- [Go to Developer Program](https://docs.kadena.io/basics/support/developer-program)
+- [Go to Developer Program](/basics/support/developer-program)

--- a/docs/basics/resources/Pact.md
+++ b/docs/basics/resources/Pact.md
@@ -4,10 +4,10 @@ description: Resources to start building on Kadena with Pact.
 
 # Pact Resources
 
-* [Kadena developer quickstart](https://docs.kadena.io/basics/quickstart): learn Kadena’s core concepts & tools for development in 15 minutes.
-* [Pact developer tutorials](https://docs.kadena.io/learn-pact/intro): Learn Pact's fundamental concepts through structured lessons and sample projects:
-* [Pact local queries:](https://docs.kadena.io/build/pact-local-api-queries) Describes how to use `local` API endpoints to dry-run smart contracts using Mainnet data (Community contribution)
-* [Safe rotate and drain ](https://docs.kadena.io/build/safe-rotate-and-drain)(example): Describes how to rotate an account’s key then transfer the account’s balance to another account (Community contribution)
-* [Safe transfer ](https://docs.kadena.io/build/safe-transfer)(example): Describes how to perform a safe transfer by requiring the recipient to also sign and return some KDA all within a single transaction (Community contribution)
+* [Kadena developer quickstart](/basics/quickstart): learn Kadena’s core concepts & tools for development in 15 minutes.
+* [Pact developer tutorials](/learn-pact/intro): Learn Pact's fundamental concepts through structured lessons and sample projects:
+* [Pact local queries:](/build/pact-local-api-queries) Describes how to use `local` API endpoints to dry-run smart contracts using Mainnet data (Community contribution)
+* [Safe rotate and drain ](/build/safe-rotate-and-drain)(example): Describes how to rotate an account’s key then transfer the account’s balance to another account (Community contribution)
+* [Safe transfer ](/build/safe-transfer)(example): Describes how to perform a safe transfer by requiring the recipient to also sign and return some KDA all within a single transaction (Community contribution)
 * [Deploy a module to Testnet using command line](https://gist.github.com/LindaOrtega/1c219f887d9782c6745dbd827bdbfb4d) (example): (Community contribution)
 * [Kadena teaches](https://www.youtube.com/playlist?list=PL4G3uLl2K-dm18c1QGo7T6NXJh2CSzXVf): tutorial videos covering Chainweb and Pact core mechanisms.

--- a/docs/basics/resources/Pact.md
+++ b/docs/basics/resources/Pact.md
@@ -6,8 +6,8 @@ description: Resources to start building on Kadena with Pact.
 
 * [Kadena developer quickstart](/basics/quickstart): learn Kadena’s core concepts & tools for development in 15 minutes.
 * [Pact developer tutorials](/learn-pact/intro): Learn Pact's fundamental concepts through structured lessons and sample projects:
-* [Pact local queries:](/build/pact-local-api-queries) Describes how to use `local` API endpoints to dry-run smart contracts using Mainnet data (Community contribution)
-* [Safe rotate and drain ](/build/safe-rotate-and-drain)(example): Describes how to rotate an account’s key then transfer the account’s balance to another account (Community contribution)
-* [Safe transfer ](/build/safe-transfer)(example): Describes how to perform a safe transfer by requiring the recipient to also sign and return some KDA all within a single transaction (Community contribution)
+* [Pact local queries:](/build/local-api-queries) Describes how to use `local` API endpoints to dry-run smart contracts using Mainnet data (Community contribution)
+* [Safe rotate and drain ](/build/guides/safe-rotate-and-drain)(example): Describes how to rotate an account’s key then transfer the account’s balance to another account (Community contribution)
+* [Safe transfer ](/build/guides/safe-transfer)(example): Describes how to perform a safe transfer by requiring the recipient to also sign and return some KDA all within a single transaction (Community contribution)
 * [Deploy a module to Testnet using command line](https://gist.github.com/LindaOrtega/1c219f887d9782c6745dbd827bdbfb4d) (example): (Community contribution)
 * [Kadena teaches](https://www.youtube.com/playlist?list=PL4G3uLl2K-dm18c1QGo7T6NXJh2CSzXVf): tutorial videos covering Chainweb and Pact core mechanisms.

--- a/docs/basics/wallets.md
+++ b/docs/basics/wallets.md
@@ -18,7 +18,7 @@ KDA custody tools for desktop and mobile, with support guides to get you started
 Official Kadena wallet for advanced blockchain usage and smart contract development.
 The desktop edition has a signing API to interact with dApps on Kadena Chainweb.
 
-[User Guide](https://docs.kadena.io/basics/chainweaver/chainweaver-user-guide)
+[User Guide](/basics/chainweaver/chainweaver-user-guide)
 
 [Web beta](https://chainweaver.kadena.network)
 

--- a/docs/basics/whitepapers/chainweb-layer-1.md
+++ b/docs/basics/whitepapers/chainweb-layer-1.md
@@ -11,25 +11,25 @@ import TabItem from '@theme/TabItem';
 Kadena's public blockchain, Chainweb, is the only sharded and scalable layer-1 PoW network 
 in production today. It utilizes a PoW (Proof of Work) consensus mechanism that improves throughput and scalability without sacrificing security.
 
-### Kadena public summary paper[​](https://docs.kadena.io/basics/whitepapers/chainweb-layer-1#kadena-public-summary-paper) <a href="#kadena-public-summary-paper" id="kadena-public-summary-paper"></a>
+### Kadena public summary paper[​](/basics/whitepapers/chainweb-layer-1#kadena-public-summary-paper) <a href="#kadena-public-summary-paper" id="kadena-public-summary-paper"></a>
 
 [Read the Whitepaper](https://d31d887a-c1e0-47c2-aa51-c69f9f998b07.filesusr.com/ugd/86a16f\_1e25e5ac5db44fb7b7e4eb2fe845ce2d.pdf)
 
 William Martino and Stuart Popejoy, November 2018
 
-### Chainweb whitepaper[​](https://docs.kadena.io/basics/whitepapers/chainweb-layer-1#chainweb-whitepaper) <a href="#chainweb-whitepaper" id="chainweb-whitepaper"></a>
+### Chainweb whitepaper[​](/basics/whitepapers/chainweb-layer-1#chainweb-whitepaper) <a href="#chainweb-whitepaper" id="chainweb-whitepaper"></a>
 
 [Read the Whitepaper](https://d31d887a-c1e0-47c2-aa51-c69f9f998b07.filesusr.com/ugd/86a16f\_029c9991469e4565a7c334dd716345f4.pdf)
 
 William Martino, Stuart Popejoy, Monica Quaintance, January 2018
 
-### Chainweb protocol security calculations[​](https://docs.kadena.io/basics/whitepapers/chainweb-layer-1#chainweb-protocol-security-calculations) <a href="#chainweb-protocol-security-calculations" id="chainweb-protocol-security-calculations"></a>
+### Chainweb protocol security calculations[​](/basics/whitepapers/chainweb-layer-1#chainweb-protocol-security-calculations) <a href="#chainweb-protocol-security-calculations" id="chainweb-protocol-security-calculations"></a>
 
 [Read the Whitepaper](https://d31d887a-c1e0-47c2-aa51-c69f9f998b07.filesusr.com/ugd/86a16f\_26d87f20cf8548d2927e28152babf533.pdf)
 
 Monica Quaintance, William Martino, January 2018
 
-### Chainweb updated security analysis: agent-based simulations[​](https://docs.kadena.io/basics/whitepapers/chainweb-layer-1#chainweb-updated-security-analysis-agent-based-simulations) <a href="#chainweb-updated-security-analysis-agent-based-simulations" id="chainweb-updated-security-analysis-agent-based-simulations"></a>
+### Chainweb updated security analysis: agent-based simulations[​](/basics/whitepapers/chainweb-layer-1#chainweb-updated-security-analysis-agent-based-simulations) <a href="#chainweb-updated-security-analysis-agent-based-simulations" id="chainweb-updated-security-analysis-agent-based-simulations"></a>
 
 [Read the Whitepaper](https://d31d887a-c1e0-47c2-aa51-c69f9f998b07.filesusr.com/ugd/86a16f\_3b2d0c58179d4edd9df6df4d55d61dda.pdf)
 

--- a/docs/build/guides/marmalade-tutorial.md
+++ b/docs/build/guides/marmalade-tutorial.md
@@ -190,7 +190,7 @@ A tutorial on minting a PFT with limited supply, fixed quote, and royalty.
 
 marmalade-tutorial.art Token
 
-If you haven’t already, you will need to make a Chainweaver wallet. Go to [this tutorial](https://docs.kadena.io/basics/chainweaver/chainweaver-user-guide) if you need help building one.
+If you haven’t already, you will need to make a Chainweaver wallet. Go to [this tutorial](/basics/chainweaver/chainweaver-user-guide) if you need help building one.
 
 ### Interplanetary Storage Saving
 
@@ -211,7 +211,7 @@ Although storing data on-chain is possible, and recommended for certain use case
 And once done, your file is pinned on the decentralized IPFS!
 
 1. Finally, take note of the CID from the uploaded picture and save the link with the format https://gateway.pinata.cloud/ipfs/{YourPicture’sCID}
-2. We’re now one step closer to minting the Token on-chain! Next, If you have a private public key pair, we’ll go straight to creating and minting the token. If not follow [this guide](https://docs.kadena.io/basics/chainweaver/chainweaver-user-guide#keys-accounts-and-ownership-) to make the private/public keychain and account.
+2. We’re now one step closer to minting the Token on-chain! Next, If you have a private public key pair, we’ll go straight to creating and minting the token. If not follow [this guide](/basics/chainweaver/chainweaver-user-guide#keys-accounts-and-ownership-) to make the private/public keychain and account.
 
 ### Nothing as Cold as a Mint
 

--- a/docs/build/guides/pact-local-api-queries.md
+++ b/docs/build/guides/pact-local-api-queries.md
@@ -4,7 +4,7 @@ Chainweb supports the use of the Pact smart contract language, including the `lo
 
 ### **Setup** <a href="#setup" id="setup"></a>
 
-Follow the instructions at the [Welcome to Pact](https://docs.kadena.io/learn-pact/beginner/welcome-to-pact) section to get started with Pact learning the basics. For a more straightforward and technical introduction, just [readthedocs](https://pact-language.readthedocs.io).
+Follow the instructions at the [Welcome to Pact](/learn-pact/beginner/welcome-to-pact) section to get started with Pact learning the basics. For a more straightforward and technical introduction, just [readthedocs](https://pact-language.readthedocs.io).
 
 In particular, for any script going on Chainweb, you'll need to understand the [API request format](https://pact-language.readthedocs.io/en/stable/pact-reference.html#api-request-formatter).
 

--- a/docs/build/guides/pact-local-api-queries.md
+++ b/docs/build/guides/pact-local-api-queries.md
@@ -4,7 +4,7 @@ Chainweb supports the use of the Pact smart contract language, including the `lo
 
 ### **Setup** <a href="#setup" id="setup"></a>
 
-Follow the instructions at [pactlang.org](https://pactlang.org) to get started with Pact learning the basics. For a more straightforward and technical introduction, just [readthedocs](https://pact-language.readthedocs.io).
+Follow the instructions at the [Welcome to Pact](https://docs.kadena.io/learn-pact/beginner/welcome-to-pact) section to get started with Pact learning the basics. For a more straightforward and technical introduction, just [readthedocs](https://pact-language.readthedocs.io).
 
 In particular, for any script going on Chainweb, you'll need to understand the [API request format](https://pact-language.readthedocs.io/en/stable/pact-reference.html#api-request-formatter).
 

--- a/docs/contribute/ambassadors/overview.md
+++ b/docs/contribute/ambassadors/overview.md
@@ -95,4 +95,4 @@ Yes. You would need to be separately selected for each by Kadena and if so selec
 
 **Does Kadena’s Code of Conduct Apply to me?**
 
-Yes. We encourage thoughtful, respectful and accurate dialogue about Kadena and we published a Kadena [Code of Conduct](https://docs.kadena.io/contribute/code-of-conduct) applicable to our social media communities. We expect you to abide that Code of Conduct while acting as an Ambassador and if you a Moderator or Community Channel Leader enforce that Code of Conduct in the social media channel that you moderate and/or monitor.
+Yes. We encourage thoughtful, respectful and accurate dialogue about Kadena and we published a Kadena [Code of Conduct](/contribute/code-of-conduct) applicable to our social media communities. We expect you to abide that Code of Conduct while acting as an Ambassador and if you a Moderator or Community Channel Leader enforce that Code of Conduct in the social media channel that you moderate and/or monitor.

--- a/docs/contribute/ambassadors/overview.md
+++ b/docs/contribute/ambassadors/overview.md
@@ -95,4 +95,4 @@ Yes. You would need to be separately selected for each by Kadena and if so selec
 
 **Does Kadena’s Code of Conduct Apply to me?**
 
-Yes. We encourage thoughtful, respectful and accurate dialogue about Kadena and we published a Kadena [Code of Conduct](https://www.kadena.io/code-of-conduct) applicable to our social media communities. We expect you to abide that Code of Conduct while acting as an Ambassador and if you a Moderator or Community Channel Leader enforce that Code of Conduct in the social media channel that you moderate and/or monitor.
+Yes. We encourage thoughtful, respectful and accurate dialogue about Kadena and we published a Kadena [Code of Conduct](https://docs.kadena.io/contribute/code-of-conduct) applicable to our social media communities. We expect you to abide that Code of Conduct while acting as an Ambassador and if you a Moderator or Community Channel Leader enforce that Code of Conduct in the social media channel that you moderate and/or monitor.

--- a/docs/contribute/node/start-mining.md
+++ b/docs/contribute/node/start-mining.md
@@ -13,7 +13,7 @@ import TabItem from '@theme/TabItem';
 **Resources**
 
 - [Discord chat](https://discord.io/kadena): Connect with a mining pool or get advice on your own configuration
-- [Chainweb-miner](https://github.com/kadena-io/chainweb-miner): Kadena official README for mining to the Kadena Public Blockchain
+- [Chainweb-miner](https://github.com/kadena-io/chainweb-mining-client): Kadena official README for mining to the Kadena Public Blockchain
 - [BigOlChungus](https://github.com/kadena-community/bigolchungus) (Kadena miner): Open Source Linux AMD/Nvidia OpenCL miner; one instance per card (Community contribution)
 - [KDA-Miner](https://github.com/Jacoby6000/kda-miner/releases) (Kadena miner): Open Source Linux AMD/Nvidia OpenCL miner, 10% fee (Community contribution)
 - [NoncerPro-Kadena](https://github.com/NoncerPro/Kadena) (Kadena miner): Closed Source Linux/Windows Nvidia Cuda miner, 2% fee (Community contribution)
@@ -22,8 +22,8 @@ import TabItem from '@theme/TabItem';
 
 **Guides**
 
-- [How to mine with a CPU](https://github.com/kadena-io/chainweb-miner)
-- [How to mine with a GPU](https://github.com/kadena-io/chainweb-miner)
+- [How to mine with a CPU](https://github.com/kadena-io/chainweb-mining-client)
+- [How to mine with a GPU](https://github.com/kadena-io/chainweb-mining-client)
 - [How to solo mine Kadena](https://medium.com/kadenacoin/how-to-mine-kadena-kda-c5fe1746c83d): Article on how to solo mine Kadena, by [Thanos](https://medium.com/@Thanos_42) (Community contribution)
 - [F2Pool Mining Guide](https://blog.f2pool.com/en/mining-tutorial-en/kda_en): Instruction on mining with f2pool (Community contribution)
 - [Icemining Mining Guide](https://medium.com/how-to-mine-on-icemining-pool/how-to-mine-kda-61e57545eced): Instruction on mining with icemining (Community contribution)

--- a/docs/learn-pact/beginner/accounts-and-transfers.md
+++ b/docs/learn-pact/beginner/accounts-and-transfers.md
@@ -96,7 +96,7 @@ Define and read the admin-keyset, create the payments module, and give the admin
 
 :::info
 
-If you’re unfamiliar with modules and keyset, our <a href="https://docs.kadena.io/learn-pact/beginner/modules" target="_blank">Pact Modules Tutorial</a> is a great place to get started.
+If you’re unfamiliar with modules and keyset, our <a href="/learn-pact/beginner/modules" target="_blank">Pact Modules Tutorial</a> is a great place to get started.
 
 :::
 
@@ -124,7 +124,7 @@ Define a schema and table with columns **balance** and **keyset**.
 
 :::info
 
-Schema definitions are introduced in the <a href="https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#define-schemas" target="_blank">Pact Schemas and Tables Tutorial</a>.
+Schema definitions are introduced in the <a href="/learn-pact/beginner/schemas-and-tables#define-schemas" target="_blank">Pact Schemas and Tables Tutorial</a>.
 
 :::
 
@@ -134,7 +134,7 @@ This smart contract will contain 3 functions create-account, get-balance, and pa
 
 :::info
 
-You can review each of the function types in the <a href="https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#table-built-in-functions" target="_blank">Schemas and Tables Tutorial</a> as well as the <a href="https://docs.kadena.io/learn-pact/beginner/language-basics#built-in-functions" target="_blank">Pact Language Basics Tutorial</a>.
+You can review each of the function types in the <a href="/learn-pact/beginner/schemas-and-tables#table-built-in-functions" target="_blank">Schemas and Tables Tutorial</a> as well as the <a href="/learn-pact/beginner/language-basics#built-in-functions" target="_blank">Pact Language Basics Tutorial</a>.
 
 :::
 
@@ -243,8 +243,8 @@ If you’d like, you can try deploying this smart contract. You can deploy this 
 
 For help getting started and deploying in each of these environments, try the following tutorials.
 
-- <a href="https://docs.kadena.io/learn-pact/beginner/web-editor" target="_blank">Pact Online Editor</a>
-- <a href="https://docs.kadena.io/learn-pact/beginner/atom-sdk" target="_blank">Pact Development on Atom SDK Tutorial</a>
+- <a href="/learn-pact/beginner/web-editor" target="_blank">Pact Online Editor</a>
+- <a href="/learn-pact/beginner/atom-sdk" target="_blank">Pact Development on Atom SDK Tutorial</a>
 
 ## Review
 

--- a/docs/learn-pact/beginner/accounts-and-transfers.md
+++ b/docs/learn-pact/beginner/accounts-and-transfers.md
@@ -96,7 +96,7 @@ Define and read the admin-keyset, create the payments module, and give the admin
 
 :::info
 
-If you’re unfamiliar with modules and keyset, our <a href="https://pactlang.org/beginner/pact-modules/" target="_blank">Pact Modules Tutorial</a> is a great place to get started.
+If you’re unfamiliar with modules and keyset, our <a href="https://docs.kadena.io/learn-pact/beginner/modules" target="_blank">Pact Modules Tutorial</a> is a great place to get started.
 
 :::
 
@@ -124,7 +124,7 @@ Define a schema and table with columns **balance** and **keyset**.
 
 :::info
 
-Schema definitions are introduced in the <a href="https://pactlang.org/beginner/pact-schemas-and-tables/#define-schemas" target="_blank">Pact Schemas and Tables Tutorial</a>.
+Schema definitions are introduced in the <a href="https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#define-schemas" target="_blank">Pact Schemas and Tables Tutorial</a>.
 
 :::
 
@@ -134,7 +134,7 @@ This smart contract will contain 3 functions create-account, get-balance, and pa
 
 :::info
 
-You can review each of the function types in the <a href="https://pactlang.org/beginner/pact-schemas-and-tables/#table-built-in-functions" target="_blank">Schemas and Tables Tutorial</a> as well as the <a href="https://pactlang.org/beginner/pact-language-basics/#built-in-functions" target="_blank">Pact Language Basics Tutorial</a>.
+You can review each of the function types in the <a href="https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#table-built-in-functions" target="_blank">Schemas and Tables Tutorial</a> as well as the <a href="https://docs.kadena.io/learn-pact/beginner/language-basics#built-in-functions" target="_blank">Pact Language Basics Tutorial</a>.
 
 :::
 
@@ -243,8 +243,8 @@ If you’d like, you can try deploying this smart contract. You can deploy this 
 
 For help getting started and deploying in each of these environments, try the following tutorials.
 
-- <a href="https://pactlang.org/beginner/online-editor/" target="_blank">Pact Online Editor</a>
-- <a href="https://pactlang.org/beginner/pact-on-atom-sdk/" target="_blank">Pact Development on Atom SDK Tutorial</a>
+- <a href="https://docs.kadena.io/learn-pact/beginner/web-editor" target="_blank">Pact Online Editor</a>
+- <a href="https://docs.kadena.io/learn-pact/beginner/atom-sdk" target="_blank">Pact Development on Atom SDK Tutorial</a>
 
 ## Review
 

--- a/docs/learn-pact/beginner/contract-interaction.md
+++ b/docs/learn-pact/beginner/contract-interaction.md
@@ -92,8 +92,8 @@ Each number in the image corresponds to one of the files you will work with.
 
 Both auth.pact and payments.pact are smart contracts that you have worked with in previous tutorials. If you would like to learn more about these smart contracts, feel free to view each of their tutorials.
 
-* **Auth Module:** <a href="https://pactlang.org/beginner/project-rotatable-wallet/" target="_blank">Project: Rotatable Wallet</a>
-* **Payments Module:** <a href="https://pactlang.org/beginner/pact-accounts-and-transfers/" target="_blank">Accounts and Transfers</a>
+* **Auth Module:** <a href="https://docs.kadena.io/learn-pact/beginner/rotatable-wallet/" target="_blank">Project: Rotatable Wallet</a>
+* **Payments Module:** <a href="https://docs.kadena.io/learn-pact/beginner/accounts-and-transfers/" target="_blank">Accounts and Transfers</a>
 
 :::
 
@@ -157,7 +157,7 @@ Define a function enforce-user-auth that you can use to verify user authorizatio
 
 :::info
 
-A function similar to this is covered in Challenge <a href="https://pactlang.org/beginner/project-rotatable-wallet/#42-enforce-user" target="_blank">4.2 in Project Rotatable Wallet</a>. You can look back to this challenge for more information to help get you started.
+A function similar to this is covered in Challenge <a href="https://docs.kadena.io/learn-pact/beginner/rotatable-wallet/#42-enforce-user" target="_blank">4.2 in Project Rotatable Wallet</a>. You can look back to this challenge for more information to help get you started.
 
 :::
 
@@ -282,7 +282,7 @@ Load the **auth** module into the **payments.repl** file.
 
 :::info
 
-Transactions and loading are covered in more detail in <a href="https://pactlang.org/beginner/testing-pact-code-in-the-sdk/" target="_blank">Testing Pact Code in the SDK</a>.
+Transactions and loading are covered in more detail in <a href="https://docs.kadena.io/learn-pact/beginner/test-in-the-sdk/" target="_blank">Testing Pact Code in the SDK</a>.
 
 :::
 
@@ -367,7 +367,7 @@ The output to your terminal should look similar to the image shown below.
 
 :::info
 
-For more information on running files from the terminal, view <a href="https://pactlang.org/beginner/testing-pact-code-in-the-sdk/#run-repl-file" target="_blank">Testing Pact Code in the SDK</a>.
+For more information on running files from the terminal, view <a href="https://docs.kadena.io/learn-pact/beginner/test-in-the-sdk/#run-repl-file" target="_blank">Testing Pact Code in the SDK</a>.
 
 :::
 

--- a/docs/learn-pact/beginner/contract-interaction.md
+++ b/docs/learn-pact/beginner/contract-interaction.md
@@ -92,8 +92,8 @@ Each number in the image corresponds to one of the files you will work with.
 
 Both auth.pact and payments.pact are smart contracts that you have worked with in previous tutorials. If you would like to learn more about these smart contracts, feel free to view each of their tutorials.
 
-* **Auth Module:** <a href="https://docs.kadena.io/learn-pact/beginner/rotatable-wallet/" target="_blank">Project: Rotatable Wallet</a>
-* **Payments Module:** <a href="https://docs.kadena.io/learn-pact/beginner/accounts-and-transfers/" target="_blank">Accounts and Transfers</a>
+* **Auth Module:** <a href="/learn-pact/beginner/rotatable-wallet/" target="_blank">Project: Rotatable Wallet</a>
+* **Payments Module:** <a href="/learn-pact/beginner/accounts-and-transfers/" target="_blank">Accounts and Transfers</a>
 
 :::
 
@@ -157,7 +157,7 @@ Define a function enforce-user-auth that you can use to verify user authorizatio
 
 :::info
 
-A function similar to this is covered in Challenge <a href="https://docs.kadena.io/learn-pact/beginner/rotatable-wallet/#42-enforce-user" target="_blank">4.2 in Project Rotatable Wallet</a>. You can look back to this challenge for more information to help get you started.
+A function similar to this is covered in Challenge <a href="/learn-pact/beginner/rotatable-wallet/#42-enforce-user" target="_blank">4.2 in Project Rotatable Wallet</a>. You can look back to this challenge for more information to help get you started.
 
 :::
 
@@ -282,7 +282,7 @@ Load the **auth** module into the **payments.repl** file.
 
 :::info
 
-Transactions and loading are covered in more detail in <a href="https://docs.kadena.io/learn-pact/beginner/test-in-the-sdk/" target="_blank">Testing Pact Code in the SDK</a>.
+Transactions and loading are covered in more detail in <a href="/learn-pact/beginner/test-in-the-sdk/" target="_blank">Testing Pact Code in the SDK</a>.
 
 :::
 
@@ -367,7 +367,7 @@ The output to your terminal should look similar to the image shown below.
 
 :::info
 
-For more information on running files from the terminal, view <a href="https://docs.kadena.io/learn-pact/beginner/test-in-the-sdk/#run-repl-file" target="_blank">Testing Pact Code in the SDK</a>.
+For more information on running files from the terminal, view <a href="/learn-pact/beginner/test-in-the-sdk/#run-repl-file" target="_blank">Testing Pact Code in the SDK</a>.
 
 :::
 

--- a/docs/learn-pact/beginner/hello-world.md
+++ b/docs/learn-pact/beginner/hello-world.md
@@ -44,7 +44,7 @@ To get started, navigate to the Pact online editor at <a href="http://pact.kaden
 
 :::info
 
-If you’re not familiar with the module explorer, you can learn more <a href="http://pactlang.org/beginner/pact-online-editor/#module-explorer" target="_blank">here</a>.
+If you’re not familiar with the module explorer, you can learn more <a href="https://docs.kadena.io/learn-pact/beginner/web-editor#module-explorer" target="_blank">here</a>.
 
 :::
 

--- a/docs/learn-pact/beginner/hello-world.md
+++ b/docs/learn-pact/beginner/hello-world.md
@@ -44,7 +44,7 @@ To get started, navigate to the Pact online editor at <a href="http://pact.kaden
 
 :::info
 
-If you’re not familiar with the module explorer, you can learn more <a href="https://docs.kadena.io/learn-pact/beginner/web-editor#module-explorer" target="_blank">here</a>.
+If you’re not familiar with the module explorer, you can learn more <a href="/learn-pact/beginner/web-editor#module-explorer" target="_blank">here</a>.
 
 :::
 

--- a/docs/learn-pact/beginner/keysets.md
+++ b/docs/learn-pact/beginner/keysets.md
@@ -388,7 +388,7 @@ Investigate the smart contract to try and determine why you are getting the resp
 
 ### Deploy the Contract
 
-You are now ready to deploy the **Simple Payments** smart contract. For information on deploying a smart contract, view <a href="https://docs.kadena.io/learn-pact/beginner/hello-world/#deploy-to-the-testnet" target="_blank">Deploy to the Testnet</a> from the Hello World with Pact tutorial.
+You are now ready to deploy the **Simple Payments** smart contract. For information on deploying a smart contract, view <a href="/learn-pact/beginner/hello-world/#deploy-to-the-testnet" target="_blank">Deploy to the Testnet</a> from the Hello World with Pact tutorial.
 
 ### **Deployed Payments Contract Function Call**
 

--- a/docs/learn-pact/beginner/keysets.md
+++ b/docs/learn-pact/beginner/keysets.md
@@ -388,7 +388,7 @@ Investigate the smart contract to try and determine why you are getting the resp
 
 ### Deploy the Contract
 
-You are now ready to deploy the **Simple Payments** smart contract. For information on deploying a smart contract, view <a href="https://pactlang.org/beginner/hello-world-with-pact/#deploy-to-the-testnet" target="_blank">Deploy to the Testnet</a> from the Hello World with Pact tutorial.
+You are now ready to deploy the **Simple Payments** smart contract. For information on deploying a smart contract, view <a href="https://docs.kadena.io/learn-pact/beginner/hello-world/#deploy-to-the-testnet" target="_blank">Deploy to the Testnet</a> from the Hello World with Pact tutorial.
 
 ### **Deployed Payments Contract Function Call**
 

--- a/docs/learn-pact/beginner/language-basics.md
+++ b/docs/learn-pact/beginner/language-basics.md
@@ -34,7 +34,7 @@ The <a href="https://pact-language.readthedocs.io/en/latest/" target="_blank">Pa
 :::info Follow Along
 Open the online editor at <a href="https://pact.kadena.io/" target="_blank">pact.kadena.io</a> to follow along with this tutorial. You can run each of the commands described to get more familiar with the Pact programming language.
 
-       View the <a href="https://docs.kadena.io/learn-pact/beginner/web-editor/" target="_blank">Pact Online Code Editor Tutorial</a> for more information on running Pact commands.
+       View the <a href="/learn-pact/beginner/web-editor/" target="_blank">Pact Online Code Editor Tutorial</a> for more information on running Pact commands.
 
 :::
 

--- a/docs/learn-pact/beginner/language-basics.md
+++ b/docs/learn-pact/beginner/language-basics.md
@@ -34,7 +34,7 @@ The <a href="https://pact-language.readthedocs.io/en/latest/" target="_blank">Pa
 :::info Follow Along
 Open the online editor at <a href="https://pact.kadena.io/" target="_blank">pact.kadena.io</a> to follow along with this tutorial. You can run each of the commands described to get more familiar with the Pact programming language.
 
-       View the <a href="https://pactlang.org/beginner/online-editor/" target="_blank">Pact Online Code Editor Tutorial</a> for more information on running Pact commands.
+       View the <a href="https://docs.kadena.io/learn-pact/beginner/web-editor/" target="_blank">Pact Online Code Editor Tutorial</a> for more information on running Pact commands.
 
 :::
 

--- a/docs/learn-pact/beginner/loans.md
+++ b/docs/learn-pact/beginner/loans.md
@@ -102,7 +102,7 @@ Create a keyset named **loans-admin-keyset** and a module named **loans** that s
 
 :::info
 
-If you’re unfamiliar with modules and keyset, our <a href="https://pactlang.org/beginner/pact-modules/" target="_blank">Pact Modules Tutorial</a> is a great place to get started.
+If you’re unfamiliar with modules and keyset, our <a href="https://docs.kadena.io/learn-pact/beginner/modules" target="_blank">Pact Modules Tutorial</a> is a great place to get started.
 
 :::
 
@@ -118,7 +118,7 @@ For this challenge, you’ll see each table presented as fields and types. Your 
 
 :::info
 
-Schema definitions are introduced in the <a href="https://pactlang.org/beginner/pact-schemas-and-tables/#define-schemas" target="_blank">Pact Schemas and Tables Tutorial</a>.
+Schema definitions are introduced in the <a href="https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#define-schemas" target="_blank">Pact Schemas and Tables Tutorial</a>.
 
 :::
 
@@ -200,7 +200,7 @@ Take some time now to define each of the tables for the loans smart contract.
 
 :::info
 
-Table definitions are covered in the <a href="https://pactlang.org/beginner/pact-schemas-and-tables/#define-tables" target="_blank">Pact Schemas and Tables Tutorial</a>.
+Table definitions are covered in the <a href="https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#define-tables" target="_blank">Pact Schemas and Tables Tutorial</a>.
 
 :::
 
@@ -240,7 +240,7 @@ The functions you’ll create in the loans smart contract will use combinations 
 
 :::info
 
-You can review each of these function types in the <a href="https://pactlang.org/beginner/pact-schemas-and-tables/#table-built-in-functions" target="_blank">Pact Schemas and Tables Tutorial</a>.
+You can review each of these function types in the <a href="https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#table-built-in-functions" target="_blank">Pact Schemas and Tables Tutorial</a>.
 
 :::
 
@@ -456,7 +456,7 @@ Take some time now to create each of the tables for the loans smart contract.
 
 :::info
 
-Table creation is covered in the [Tables and Schemas Tutorial](https://pactlang.org/beginner/pact-schemas-and-tables/#create-tables).
+Table creation is covered in the [Tables and Schemas Tutorial](https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#create-tables).
 
 :::
 
@@ -468,8 +468,8 @@ If you’d like, you can try deploying this smart contract. You can deploy this 
 
 For help getting started and deploying in each of these environments, try the following tutorials.
 
-- [Pact Online Editor](https://pactlang.org/beginner/online-editor/)
-- [Pact Development on Atom SDK Tutorial](https://pactlang.org/beginner/pact-on-atom-sdk/)
+- [Pact Online Editor](https://docs.kadena.io/learn-pact/beginner/web-editor/)
+- [Pact Development on Atom SDK Tutorial](https://docs.kadena.io/learn-pact/beginner/atom-sdk)
 
 ## Review
 

--- a/docs/learn-pact/beginner/loans.md
+++ b/docs/learn-pact/beginner/loans.md
@@ -102,7 +102,7 @@ Create a keyset named **loans-admin-keyset** and a module named **loans** that s
 
 :::info
 
-If you’re unfamiliar with modules and keyset, our <a href="https://docs.kadena.io/learn-pact/beginner/modules" target="_blank">Pact Modules Tutorial</a> is a great place to get started.
+If you’re unfamiliar with modules and keyset, our <a href="/learn-pact/beginner/modules" target="_blank">Pact Modules Tutorial</a> is a great place to get started.
 
 :::
 
@@ -118,7 +118,7 @@ For this challenge, you’ll see each table presented as fields and types. Your 
 
 :::info
 
-Schema definitions are introduced in the <a href="https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#define-schemas" target="_blank">Pact Schemas and Tables Tutorial</a>.
+Schema definitions are introduced in the <a href="/learn-pact/beginner/schemas-and-tables#define-schemas" target="_blank">Pact Schemas and Tables Tutorial</a>.
 
 :::
 
@@ -200,7 +200,7 @@ Take some time now to define each of the tables for the loans smart contract.
 
 :::info
 
-Table definitions are covered in the <a href="https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#define-tables" target="_blank">Pact Schemas and Tables Tutorial</a>.
+Table definitions are covered in the <a href="/learn-pact/beginner/schemas-and-tables#define-tables" target="_blank">Pact Schemas and Tables Tutorial</a>.
 
 :::
 
@@ -240,7 +240,7 @@ The functions you’ll create in the loans smart contract will use combinations 
 
 :::info
 
-You can review each of these function types in the <a href="https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#table-built-in-functions" target="_blank">Pact Schemas and Tables Tutorial</a>.
+You can review each of these function types in the <a href="/learn-pact/beginner/schemas-and-tables#table-built-in-functions" target="_blank">Pact Schemas and Tables Tutorial</a>.
 
 :::
 
@@ -456,7 +456,7 @@ Take some time now to create each of the tables for the loans smart contract.
 
 :::info
 
-Table creation is covered in the [Tables and Schemas Tutorial](https://docs.kadena.io/learn-pact/beginner/schemas-and-tables#create-tables).
+Table creation is covered in the [Tables and Schemas Tutorial](/learn-pact/beginner/schemas-and-tables#create-tables).
 
 :::
 
@@ -468,8 +468,8 @@ If you’d like, you can try deploying this smart contract. You can deploy this 
 
 For help getting started and deploying in each of these environments, try the following tutorials.
 
-- [Pact Online Editor](https://docs.kadena.io/learn-pact/beginner/web-editor/)
-- [Pact Development on Atom SDK Tutorial](https://docs.kadena.io/learn-pact/beginner/atom-sdk)
+- [Pact Online Editor](/learn-pact/beginner/web-editor/)
+- [Pact Development on Atom SDK Tutorial](/learn-pact/beginner/atom-sdk)
 
 ## Review
 

--- a/docs/learn-pact/beginner/modules.md
+++ b/docs/learn-pact/beginner/modules.md
@@ -96,7 +96,7 @@ You can find examples using the Module Explorer in the <a href="https://pact.kad
 
 #### Hello World
 
-From the Module Explorer, open the Hello World Smart Contract. If you’re interested, this smart contract is explained in depth in the <a href="https://pactlang.org/beginner/hello-world-with-pact/" target="_blank">Hello World with Pact</a>.
+From the Module Explorer, open the Hello World Smart Contract. If you’re interested, this smart contract is explained in depth in the <a href="https://docs.kadena.io/learn-pact/beginner/hello-world/" target="_blank">Hello World with Pact</a>.
 
 Notice that the pattern of this smart contract is similar to the outline described above.
 

--- a/docs/learn-pact/beginner/modules.md
+++ b/docs/learn-pact/beginner/modules.md
@@ -96,7 +96,7 @@ You can find examples using the Module Explorer in the <a href="https://pact.kad
 
 #### Hello World
 
-From the Module Explorer, open the Hello World Smart Contract. If you’re interested, this smart contract is explained in depth in the <a href="https://docs.kadena.io/learn-pact/beginner/hello-world/" target="_blank">Hello World with Pact</a>.
+From the Module Explorer, open the Hello World Smart Contract. If you’re interested, this smart contract is explained in depth in the <a href="/learn-pact/beginner/hello-world/" target="_blank">Hello World with Pact</a>.
 
 Notice that the pattern of this smart contract is similar to the outline described above.
 

--- a/docs/learn-pact/beginner/rotatable-wallet.md
+++ b/docs/learn-pact/beginner/rotatable-wallet.md
@@ -280,9 +280,9 @@ Your Rotatable Wallet smart contract is complete! If you’d like, you can deplo
 
 For more information on deploying this smart contract, view the following tutorials.
 
-- <a href="https://docs.kadena.io/learn-pact/beginner/hello-world" target="_blank">Hello World with Pact</a>
-- <a href="https://docs.kadena.io/learn-pact/beginner/web-editor" target="_blank">Pact Online Editor</a>
-- <a href="https://docs.kadena.io/learn-pact/beginner/atom-sdk" target="_blank">Pact Development on Atom SDK</a>
+- <a href="/learn-pact/beginner/hello-world" target="_blank">Hello World with Pact</a>
+- <a href="/learn-pact/beginner/web-editor" target="_blank">Pact Online Editor</a>
+- <a href="/learn-pact/beginner/atom-sdk" target="_blank">Pact Development on Atom SDK</a>
 
 ## Review
 

--- a/docs/learn-pact/beginner/rotatable-wallet.md
+++ b/docs/learn-pact/beginner/rotatable-wallet.md
@@ -280,9 +280,9 @@ Your Rotatable Wallet smart contract is complete! If you’d like, you can deplo
 
 For more information on deploying this smart contract, view the following tutorials.
 
-- <a href="https://pactlang.org/beginner/hello-world-with-pact/" target="_blank">Hello World with Pact</a>
-- <a href="https://pactlang.org/beginner/online-editor/" target="_blank">Pact Online Editor</a>
-- <a href="https://pactlang.org/beginner/pact-on-atom-sdk/" target="_blank">Pact Development on Atom SDK</a>
+- <a href="https://docs.kadena.io/learn-pact/beginner/hello-world" target="_blank">Hello World with Pact</a>
+- <a href="https://docs.kadena.io/learn-pact/beginner/web-editor" target="_blank">Pact Online Editor</a>
+- <a href="https://docs.kadena.io/learn-pact/beginner/atom-sdk" target="_blank">Pact Development on Atom SDK</a>
 
 ## Review
 

--- a/docs/learn-pact/beginner/test-in-the-sdk.md
+++ b/docs/learn-pact/beginner/test-in-the-sdk.md
@@ -44,9 +44,9 @@ Subscribe to our <a href="https://www.youtube.com/channel/UCB6-MaxD2hlcGLL70ukHo
 
 Before starting this tutorial, it helps to have completed the following pre-requisites.
 
-- <a href="https://docs.kadena.io/learn-pact/beginner/atom-sdk" target="_blank">Pact Development on Atom SDK</a>: The SDK is required for testing in the SDK. You can get up and running with the SDK using this tutorial.
+- <a href="/learn-pact/beginner/atom-sdk" target="_blank">Pact Development on Atom SDK</a>: The SDK is required for testing in the SDK. You can get up and running with the SDK using this tutorial.
 
-- <a href="https://docs.kadena.io/learn-pact/beginner/loans/" target="_blank">Project: Loans</a>: You will be building a REPL file for the Loans project covered in a separate tutorial. This isn’t required but is a helpful way to better understand the smart contract used throughout this tutorial.
+- <a href="/learn-pact/beginner/loans/" target="_blank">Project: Loans</a>: You will be building a REPL file for the Loans project covered in a separate tutorial. This isn’t required but is a helpful way to better understand the smart contract used throughout this tutorial.
 
 ## REPL Overview
 
@@ -266,9 +266,9 @@ For this code challenge, you will need to make calls to a few functions from the
 
 | function                                                                                                  | purpose                                                             |
 | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| <a href="https://docs.kadena.io/learn-pact/beginner/loans/#52-create-a-loan" target="_blank">create-a-loan</a> | Accepts parameters to add the appropriate information to each table |
-| <a href="https://docs.kadena.io/learn-pact/beginner/loans/#53-assign-a-loan" target="_blank">assign-a-loan</a> | Assigns a loan to an entity.                                        |
-| <a href="https://docs.kadena.io/learn-pact/beginner/loans/#54-sell-a-loan" target="_blank">sell-a-loan</a>     | Sell a loan and log details in the loan history table.              |
+| <a href="/learn-pact/beginner/loans/#52-create-a-loan" target="_blank">create-a-loan</a> | Accepts parameters to add the appropriate information to each table |
+| <a href="/learn-pact/beginner/loans/#53-assign-a-loan" target="_blank">assign-a-loan</a> | Assigns a loan to an entity.                                        |
+| <a href="/learn-pact/beginner/loans/#54-sell-a-loan" target="_blank">sell-a-loan</a>     | Sell a loan and log details in the loan history table.              |
 
 Follow the links provided or view the loans.pact file for more details.
 
@@ -283,7 +283,7 @@ Call the **create-a-loan**, **assign-a-loan**, and **sell-a-loan** functions fro
 
 :::info
 
-If you have not already completed the <a href="https://docs.kadena.io/learn-pact/beginner/loans/" target="_blank">Project: Loans tutorial</a>, try working through this tutorial to build the entire Loans smart contract for yourself!
+If you have not already completed the <a href="/learn-pact/beginner/loans/" target="_blank">Project: Loans tutorial</a>, try working through this tutorial to build the entire Loans smart contract for yourself!
 
 :::
 
@@ -295,8 +295,8 @@ Here is a brief overview of the functions you will call in this challenge.
 
 | function                                                                                                                     | purpose                                      |
 | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| <a href="https://docs.kadena.io/learn-pact/beginner/loans/#59-read-loan-inventory" target="_blank">read-loan-inventory</a>        | Reads all loans in the loan inventory table. |
-| <a href="https://docs.kadena.io/learn-pact/beginner/loans/#510-read-loans-with-status" target="_blank">read-loans-with-status</a> | Reads all loans with a specific status.      |
+| <a href="/learn-pact/beginner/loans/#59-read-loan-inventory" target="_blank">read-loan-inventory</a>        | Reads all loans in the loan inventory table. |
+| <a href="/learn-pact/beginner/loans/#510-read-loans-with-status" target="_blank">read-loans-with-status</a> | Reads all loans with a specific status.      |
 
 :::caution Code Challenge
 

--- a/docs/learn-pact/beginner/test-in-the-sdk.md
+++ b/docs/learn-pact/beginner/test-in-the-sdk.md
@@ -44,9 +44,9 @@ Subscribe to our <a href="https://www.youtube.com/channel/UCB6-MaxD2hlcGLL70ukHo
 
 Before starting this tutorial, it helps to have completed the following pre-requisites.
 
-- <a href="https://pactlang.org/beginner/pact-on-atom-sdk/" target="_blank">Pact Development on Atom SDK</a>: The SDK is required for testing in the SDK. You can get up and running with the SDK using this tutorial.
+- <a href="https://docs.kadena.io/learn-pact/beginner/atom-sdk" target="_blank">Pact Development on Atom SDK</a>: The SDK is required for testing in the SDK. You can get up and running with the SDK using this tutorial.
 
-- <a href="https://pactlang.org/beginner/project-loans/" target="_blank">Project: Loans</a>: You will be building a REPL file for the Loans project covered in a separate tutorial. This isn’t required but is a helpful way to better understand the smart contract used throughout this tutorial.
+- <a href="https://docs.kadena.io/learn-pact/beginner/loans/" target="_blank">Project: Loans</a>: You will be building a REPL file for the Loans project covered in a separate tutorial. This isn’t required but is a helpful way to better understand the smart contract used throughout this tutorial.
 
 ## REPL Overview
 
@@ -266,9 +266,9 @@ For this code challenge, you will need to make calls to a few functions from the
 
 | function                                                                                                  | purpose                                                             |
 | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| <a href="https://pactlang.org/beginner/project-loans/#52-create-a-loan" target="_blank">create-a-loan</a> | Accepts parameters to add the appropriate information to each table |
-| <a href="https://pactlang.org/beginner/project-loans/#53-assign-a-loan" target="_blank">assign-a-loan</a> | Assigns a loan to an entity.                                        |
-| <a href="https://pactlang.org/beginner/project-loans/#54-sell-a-loan" target="_blank">sell-a-loan</a>     | Sell a loan and log details in the loan history table.              |
+| <a href="https://docs.kadena.io/learn-pact/beginner/loans/#52-create-a-loan" target="_blank">create-a-loan</a> | Accepts parameters to add the appropriate information to each table |
+| <a href="https://docs.kadena.io/learn-pact/beginner/loans/#53-assign-a-loan" target="_blank">assign-a-loan</a> | Assigns a loan to an entity.                                        |
+| <a href="https://docs.kadena.io/learn-pact/beginner/loans/#54-sell-a-loan" target="_blank">sell-a-loan</a>     | Sell a loan and log details in the loan history table.              |
 
 Follow the links provided or view the loans.pact file for more details.
 
@@ -283,7 +283,7 @@ Call the **create-a-loan**, **assign-a-loan**, and **sell-a-loan** functions fro
 
 :::info
 
-If you have not already completed the <a href="https://pactlang.org/beginner/project-loans/" target="_blank">Project: Loans tutorial</a>, try working through this tutorial to build the entire Loans smart contract for yourself!
+If you have not already completed the <a href="https://docs.kadena.io/learn-pact/beginner/loans/" target="_blank">Project: Loans tutorial</a>, try working through this tutorial to build the entire Loans smart contract for yourself!
 
 :::
 
@@ -295,8 +295,8 @@ Here is a brief overview of the functions you will call in this challenge.
 
 | function                                                                                                                     | purpose                                      |
 | ---------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| <a href="https://pactlang.org/beginner/project-loans/#59-read-loan-inventory" target="_blank">read-loan-inventory</a>        | Reads all loans in the loan inventory table. |
-| <a href="https://pactlang.org/beginner/project-loans/#510-read-loans-with-status" target="_blank">read-loans-with-status</a> | Reads all loans with a specific status.      |
+| <a href="https://docs.kadena.io/learn-pact/beginner/loans/#59-read-loan-inventory" target="_blank">read-loan-inventory</a>        | Reads all loans in the loan inventory table. |
+| <a href="https://docs.kadena.io/learn-pact/beginner/loans/#510-read-loans-with-status" target="_blank">read-loans-with-status</a> | Reads all loans with a specific status.      |
 
 :::caution Code Challenge
 

--- a/docs/learn-pact/beginner/web-editor.md
+++ b/docs/learn-pact/beginner/web-editor.md
@@ -95,7 +95,7 @@ Links to the Pact tutorials, developer documentation and Kadena homepage can als
 |                                                                                             |                                                                                            |
 | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | <a href="https://pact-language.readthedocs.io/en/latest/" target="_blank">Documentation</a> | Provides an in-depth look at the Pact programming language.                                |
-| <a href="https://pactlang.org/" target="_blank">Tutorials</a>                               | Learn more about Pact by completing tutorials like this.                                   |
+| <a href="https://docs.kadena.io/learn-pact/intro" target="_blank">Tutorials</a>                               | Learn more about Pact by completing tutorials like this.                                   |
 | <a href="https://kadena.io/" target="_blank">Kadena</a>                                     | Explore the Kadena blockchain, which is the enterprise-grade blockchain that Pact runs on. |
 
 :::info Join the Newsletter

--- a/docs/learn-pact/beginner/web-editor.md
+++ b/docs/learn-pact/beginner/web-editor.md
@@ -95,7 +95,7 @@ Links to the Pact tutorials, developer documentation and Kadena homepage can als
 |                                                                                             |                                                                                            |
 | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | <a href="https://pact-language.readthedocs.io/en/latest/" target="_blank">Documentation</a> | Provides an in-depth look at the Pact programming language.                                |
-| <a href="https://docs.kadena.io/learn-pact/intro" target="_blank">Tutorials</a>                               | Learn more about Pact by completing tutorials like this.                                   |
+| <a href="/learn-pact/intro" target="_blank">Tutorials</a>                               | Learn more about Pact by completing tutorials like this.                                   |
 | <a href="https://kadena.io/" target="_blank">Kadena</a>                                     | Explore the Kadena blockchain, which is the enterprise-grade blockchain that Pact runs on. |
 
 :::info Join the Newsletter

--- a/docs/learn-pact/intermediate/deploy-to-a-local-server.md
+++ b/docs/learn-pact/intermediate/deploy-to-a-local-server.md
@@ -47,7 +47,7 @@ brew install kadena-io/pact/pact
 
 :::info
 
-For more information on installing Pact, you can view the [Pact GitHub page](https://github.com/kadena-io/pact). You can also view [Atom SDK](https://pactlang.org/beginner/pact-on-atom-sdk/) from the Pact Beginner tutorial series for more information.
+For more information on installing Pact, you can view the [Pact GitHub page](https://github.com/kadena-io/pact). You can also view [Atom SDK](https://docs.kadena.io/learn-pact/beginner/atom-sdk) from the Pact Beginner tutorial series for more information.
 
 :::
 

--- a/docs/learn-pact/intermediate/deploy-to-a-local-server.md
+++ b/docs/learn-pact/intermediate/deploy-to-a-local-server.md
@@ -47,7 +47,7 @@ brew install kadena-io/pact/pact
 
 :::info
 
-For more information on installing Pact, you can view the [Pact GitHub page](https://github.com/kadena-io/pact). You can also view [Atom SDK](https://docs.kadena.io/learn-pact/beginner/atom-sdk) from the Pact Beginner tutorial series for more information.
+For more information on installing Pact, you can view the [Pact GitHub page](https://github.com/kadena-io/pact). You can also view [Atom SDK](/learn-pact/beginner/atom-sdk) from the Pact Beginner tutorial series for more information.
 
 :::
 

--- a/docs/learn-pact/intermediate/pact-and-javascript.md
+++ b/docs/learn-pact/intermediate/pact-and-javascript.md
@@ -296,7 +296,7 @@ Here is a list of functions from the smart contract along with their purpose.
 
 :::info
 
-While the code here is new, most of the functionality is covered in previous tutorials throughout the <a href="https://docs.kadena.io/learn-pact/beginner/welcome-to-pact" target="_blank">Pact beginner tutorials</a>. If you have not completed these tutorials, take some time to look through them now to get a better understanding of this Pact smart contract.
+While the code here is new, most of the functionality is covered in previous tutorials throughout the <a href="/learn-pact/beginner/welcome-to-pact" target="_blank">Pact beginner tutorials</a>. If you have not completed these tutorials, take some time to look through them now to get a better understanding of this Pact smart contract.
 
 :::
 

--- a/docs/learn-pact/intermediate/pact-and-javascript.md
+++ b/docs/learn-pact/intermediate/pact-and-javascript.md
@@ -296,7 +296,7 @@ Here is a list of functions from the smart contract along with their purpose.
 
 :::info
 
-While the code here is new, most of the functionality is covered in previous tutorials throughout the <a href="https://pactlang.org/beginner/welcome-to-pact/" target="_blank">Pact beginner tutorials</a>. If you have not completed these tutorials, take some time to look through them now to get a better understanding of this Pact smart contract.
+While the code here is new, most of the functionality is covered in previous tutorials throughout the <a href="https://docs.kadena.io/learn-pact/beginner/welcome-to-pact" target="_blank">Pact beginner tutorials</a>. If you have not completed these tutorials, take some time to look through them now to get a better understanding of this Pact smart contract.
 
 :::
 

--- a/docs/learn-pact/intermediate/safety-using-control-flow.md
+++ b/docs/learn-pact/intermediate/safety-using-control-flow.md
@@ -480,7 +480,7 @@ In my-coin.repl file, you can check that the failing cases of **debit-if** and *
 
 :::info Note
 
-For more information on running .repl files from Atom, see the tutorial [Contract Interaction > Run REPL File](https://pactlang.org/beginner/contract-interaction/#4-run-repl-file).
+For more information on running .repl files from Atom, see the tutorial [Contract Interaction > Run REPL File](https://docs.kadena.io/learn-pact/beginner/test-in-the-sdk#run-repl-file).
 
 :::
 

--- a/docs/learn-pact/intermediate/safety-using-control-flow.md
+++ b/docs/learn-pact/intermediate/safety-using-control-flow.md
@@ -480,7 +480,7 @@ In my-coin.repl file, you can check that the failing cases of **debit-if** and *
 
 :::info Note
 
-For more information on running .repl files from Atom, see the tutorial [Contract Interaction > Run REPL File](https://docs.kadena.io/learn-pact/beginner/test-in-the-sdk#run-repl-file).
+For more information on running .repl files from Atom, see the tutorial [Contract Interaction > Run REPL File](/learn-pact/beginner/test-in-the-sdk#run-repl-file).
 
 :::
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const DefaultLocale = "en";
 module.exports = {
   title: "Kadena Docs",
   tagline: "Explore the latest documentation, tutorials, code, and updates.",
-  url: "https://docs.kadena.io",
+  url: "",
   baseUrl: "/",
   trailingSlash: false,
   onBrokenLinks: "throw",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const DefaultLocale = "en";
 module.exports = {
   title: "Kadena Docs",
   tagline: "Explore the latest documentation, tutorials, code, and updates.",
-  url: "",
+  url: "https://docs.kadena.io",
   baseUrl: "/",
   trailingSlash: false,
   onBrokenLinks: "throw",


### PR DESCRIPTION
- pactlang.org was still referenced in a few places. Replaced the urls with the corresponding ones under this same docs
- Changed the reference to the archived `chainweb-miner` repository to point towards `chainweb-mining-client`
- The link for the developer program under kadena.io was [broken](https://kadena.io/developerprogram).  Replaced it with a reference to the [developer program page](https://docs.kadena.io/basics/support/developer-program) in the docs
- Similarly, the link to the [code of conduct](https://kadena.io/code-of-conduct) returned a 404. Replaced it with the [relevant section in the docs](https://docs.kadena.io/contribute/code-of-conduct)
- Removed the "https://docs.kadena.io" bit on links, as the absolute routes towards the internal docs work just fine