### PR TITLE
Proposal: add markdown-link-checker

### DIFF
--- a/.github/workflows/markdown-link-check.json
+++ b/.github/workflows/markdown-link-check.json
@@ -1,0 +1,18 @@
+{
+  "ignorePatterns": [],
+  "replacementPatterns": [
+    {
+      "pattern": "^\\.(.+/)+([^\\.#]+)(#.*)?$",
+      "replacement": ".$1$2.md"
+    },
+    {
+      "pattern": "^/(.+/)+([^\\.#]+)(#.*)?$",
+      "replacement": "{{BASEURL}}/docs/$1$2.md"
+    },
+    {
+      "pattern": "^/(img/.*)",
+      "replacement": "{{BASEURL}}/static/$1"
+    }
+  ],
+  "aliveStatusCodes": [0, 429, 200, 203]
+}

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,15 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: .github/workflows/markdown-link-check.json
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          folder-path: 'docs'

--- a/docs/basics/chainweaver/chainweaver-user-guide.md
+++ b/docs/basics/chainweaver/chainweaver-user-guide.md
@@ -64,7 +64,7 @@ With this icon
 
 :::note Help
 
-See the [Chainweaver Troubleshoot](chainweaver-troubleshooting.md) page if you encountered issues installing the .deb
+See the [Chainweaver Troubleshoot](./chainweaver-troubleshooting.md) page if you encountered issues installing the .deb
 
 :::
 
@@ -100,7 +100,7 @@ Upgrade to the latest version of Chainweaver by double-clicking the “Upgrade K
 
 :::note Help
 
-See the [Chainweaver Troubleshoot ](chainweaver-troubleshooting.md)page if you encountered issues installing the .ova
+See the [Chainweaver Troubleshoot ](./chainweaver-troubleshooting.md)page if you encountered issues installing the .ova
 
 :::
 

--- a/docs/basics/faq.md
+++ b/docs/basics/faq.md
@@ -11,19 +11,19 @@ import YouTube from '@components/YouTube';
 
 ### **Table of Contents**
 
-1. [What consensus mechanism does Kadena use?](faq.md#what-consensus-mechanism-does-kadena-use)
-2. [What hashing algorithm does Kadena use?](faq.md#what-hashing-algorithm-does-kadena-use)
-3. [What is the target block time for Kadena?](faq.md#what-is-the-target-block-time-for-kadena)
-4. [What are the block rewards?](faq.md#what-are-the-block-rewards)
-5. [Does Kadena have a block explorer?](faq.md#does-kadena-have-a-block-explorer)
-6. [Is Kadena open source?](faq.md#is-kadena-open-source)
-7. [Why does Kadena’s public blockchain use proof of work?](faq.md#why-does-kadenas-public-blockchain-use-proof-of-work)
-8. [How does Kadena scale?](faq.md#how-does-kadena-scale)
-9. [How does Kadena deal with congestion?](faq.md#how-does-kadena-deal-with-congestion)
-10. [What does it mean to “braid multiple chains”?](faq.md#what-does-it-mean-to-braid-multiple-chains)
-11. [How are tokens moved between different Kadena chains?](faq.md#how-are-tokens-moved-between-different-kadena-chains)
-12. [How do I run a node?](faq.md#how-do-i-run-a-node)
-13. [How do I become a miner?](faq.md#how-do-i-become-a-miner)
+1. [What consensus mechanism does Kadena use?](./faq.md#what-consensus-mechanism-does-kadena-use)
+2. [What hashing algorithm does Kadena use?](./faq.md#what-hashing-algorithm-does-kadena-use)
+3. [What is the target block time for Kadena?](./faq.md#what-is-the-target-block-time-for-kadena)
+4. [What are the block rewards?](./faq.md#what-are-the-block-rewards)
+5. [Does Kadena have a block explorer?](./faq.md#does-kadena-have-a-block-explorer)
+6. [Is Kadena open source?](./faq.md#is-kadena-open-source)
+7. [Why does Kadena’s public blockchain use proof of work?](./faq.md#why-does-kadenas-public-blockchain-use-proof-of-work)
+8. [How does Kadena scale?](./faq.md#how-does-kadena-scale)
+9. [How does Kadena deal with congestion?](./faq.md#how-does-kadena-deal-with-congestion)
+10. [What does it mean to “braid multiple chains”?](./faq.md#what-does-it-mean-to-braid-multiple-chains)
+11. [How are tokens moved between different Kadena chains?](./faq.md#how-are-tokens-moved-between-different-kadena-chains)
+12. [How do I run a node?](./faq.md#how-do-i-run-a-node)
+13. [How do I become a miner?](./faq.md#how-do-i-become-a-miner)
 
 ### **What consensus mechanism does Kadena use?**
 

--- a/docs/basics/quickstart.md
+++ b/docs/basics/quickstart.md
@@ -63,7 +63,7 @@ Setup Chainweaver, Kadena’s official wallet and developer workbench.
 - Record recovery phrase
 - Verify recovery phrase
 
-To download Chainweaver and find detailed instructions on Chainweaver usage go here [Chainweaver User Guide](chainweaver/chainweaver-user-guide).
+To download Chainweaver and find detailed instructions on Chainweaver usage go here [Chainweaver User Guide](./chainweaver/chainweaver-user-guide).
 
 ## Testnet Account Setup
 

--- a/docs/basics/support/developer-program.md
+++ b/docs/basics/support/developer-program.md
@@ -24,7 +24,7 @@ Kadena's Developer Program is designed to help committed developers build high-i
 
 ### Apply today!
 
-Contact Jeffrey on Discord (Jef\_f#2495) or Telegram (@SpaceJeff) to start your enrolment.
+Contact Jeffrey on Discord (Jef\_f#2495) or Telegram (@SpaceJeff) to start your enrollment.
 
 ### FAQ
 

--- a/docs/basics/whitepapers/overview.md
+++ b/docs/basics/whitepapers/overview.md
@@ -22,7 +22,7 @@ In 2020, Kadena's public blockchain performed a live network expansion from 10 c
 **Informational Resources**
 
 - Article: [Kadena’s Public Blockchain 101](https://medium.com/kadena-io/all-about-chainweb-101-and-faqs-6bd88c325b45)
-- Whitepapers: [Chainweb layer 1](chainweb-layer-1.md)
+- Whitepapers: [Chainweb layer 1](./chainweb-layer-1.md)
 - Article: [How to scale a Proof of Work Blockchain](https://medium.com/kadena-io/how-to-scale-a-proof-of-work-blockchain-9233e5b4b62)&#x20;
 
 :::note
@@ -38,7 +38,7 @@ Pact is a human readable and Turing Incomplete smart contract language purpose-b
 #### **Informational Resources**
 
 - Article: [Safer, Smarter Contracts with Pact](https://medium.com/kadena-io/safer-smarter-contracts-with-pact-e86b9ccaca9f)
-- Whitepaper: [Pact Smart Contract Language](pact-smart-contract-language.md)
+- Whitepaper: [Pact Smart Contract Language](./pact-smart-contract-language.md)
 - Documentation: [Pact GitHub](https://github.com/kadena-io/pact)
 - Documentation: [Pact Language Reference](https://pact-language.readthedocs.io/en/latest/pact-reference.html)
 
@@ -55,7 +55,7 @@ Kuro has been proven to support up to 8,000 transactions per second across 500 n
 **Informational Resources**
 
 - Article: [Kadena's layer 2 blockchain 101](https://medium.com/kadena-io/scalablebft-kadenas-private-blockchain-101-c99895c0fd50)
-- Whitepaper: [Kuro layer 2](kuro-layer-2.md)
+- Whitepaper: [Kuro layer 2](./kuro-layer-2.md)
 
 :::note
 
@@ -73,7 +73,7 @@ With 20 chains, the Kadena blockchain platform achieves an industry-leading 480,
 
 - Article: [Kadena completes blockchain scaling to 480,000 TPS on 20 Chains](https://medium.com/kadena-io/kadena-completes-hybrid-blockchain-scaling-to-480-000-transactions-per-second-on-20-chains-5a652295533c)
 - Article: [Kadena's layer 2 blockchain 101](https://medium.com/kadena-io/scalablebft-kadenas-private-blockchain-101-c99895c0fd50)
-- Whitepaper: [Kuro layer 2](kuro-layer-2.md)
+- Whitepaper: [Kuro layer 2](./kuro-layer-2.md)
 
 :::note
 

--- a/docs/build/guides/a-step-by-step-guide-to-writing-pact-smart-contract.md
+++ b/docs/build/guides/a-step-by-step-guide-to-writing-pact-smart-contract.md
@@ -6,14 +6,14 @@ Goliath Faucet Contract Goliath Wallet UI with TypeScript + React frontend The p
 
 ### Content
 
-1. [Overview](a-step-by-step-guide-to-writing-pact-smart-contract.md#overview)
-2. [Introduction](a-step-by-step-guide-to-writing-pact-smart-contract.md#introduction)
-3. [Namespaces](a-step-by-step-guide-to-writing-pact-smart-contract.md#namespaces)
-4. [Keysets](a-step-by-step-guide-to-writing-pact-smart-contract.md#keysets)
-5. [Interfaces & Modules](a-step-by-step-guide-to-writing-pact-smart-contract.md#interfaces-and-modules)
-6. [Constants](a-step-by-step-guide-to-writing-pact-smart-contract.md#constants)
-7. [Capabilities](a-step-by-step-guide-to-writing-pact-smart-contract.md#capabilities)
-8. [Functions](a-step-by-step-guide-to-writing-pact-smart-contract.md#functions)
+1. [Overview](./a-step-by-step-guide-to-writing-pact-smart-contract.md#overview)
+2. [Introduction](./a-step-by-step-guide-to-writing-pact-smart-contract.md#introduction)
+3. [Namespaces](./a-step-by-step-guide-to-writing-pact-smart-contract.md#namespaces)
+4. [Keysets](./a-step-by-step-guide-to-writing-pact-smart-contract.md#keysets)
+5. [Interfaces & Modules](./a-step-by-step-guide-to-writing-pact-smart-contract.md#interfaces-and-modules)
+6. [Constants](./a-step-by-step-guide-to-writing-pact-smart-contract.md#constants)
+7. [Capabilities](./a-step-by-step-guide-to-writing-pact-smart-contract.md#capabilities)
+8. [Functions](./a-step-by-step-guide-to-writing-pact-smart-contract.md#functions)
 
 {% hint style="info" %}
 **Tip**

--- a/docs/build/resources/developer-program.md
+++ b/docs/build/resources/developer-program.md
@@ -33,17 +33,17 @@ Kadena's Developer Program is designed to help committed developers build high-i
 
 ## Apply today!
 
-Contact Jeffrey on Discord (Jef_f#2495) or Telegram (@SpaceJeff) to start your enrolment.&#x20;
+Contact Jeffrey on Discord (Jef_f#2495) or Telegram (@SpaceJeff) to start your enrollment.
 
 ## FAQ
 
-### **Who can enrol in this program?**
+### **Who can enroll in this program?**
 
 The program is for developers who intend to launch applications on Kadena. It is open to professional developers and organizations, as well as enthusiast developers and students.
 
-### **When will my enrolment become activated?**
+### **When will my enrollment become activated?**
 
-Kadena will respond to your enrolment request within a week of submission. Anticipate receiving an email to the address provided in the request form.
+Kadena will respond to your enrollment request within a week of submission. Anticipate receiving an email to the address provided in the request form.
 
 ### **Does Kadena endorse any specific development areas or use cases?**
 

--- a/docs/build/useful-tools.md
+++ b/docs/build/useful-tools.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 ---
 
-- [Chainweaver (Wallet & Workbench)](../basics/chainweaver/chainweaver-user-guide/)
+- [Chainweaver (Wallet & Workbench)](../basics/chainweaver/chainweaver-user-guide)
 - [Atom IDE](/learn-pact/beginner/atom-sdk)
 - [Block Explorer](https://explorer.chainweb.com/mainnet)
 - [Web transfer tools](https://transfer.chainweb.com)

--- a/docs/learn-pact/beginner/loans.md
+++ b/docs/learn-pact/beginner/loans.md
@@ -468,7 +468,7 @@ If you’d like, you can try deploying this smart contract. You can deploy this 
 
 For help getting started and deploying in each of these environments, try the following tutorials.
 
-- [Pact Online Editor](/learn-pact/beginner/web-editor/)
+- [Pact Online Editor](/learn-pact/beginner/web-editor)
 - [Pact Development on Atom SDK Tutorial](/learn-pact/beginner/atom-sdk)
 
 ## Review

--- a/docs/learn-pact/beginner/welcome-to-pact.md
+++ b/docs/learn-pact/beginner/welcome-to-pact.md
@@ -43,7 +43,7 @@ Pact is an open-source programming language for writing **smart contracts**.
 
 It’s designed from the ground up to support the unique challenges of developing solutions to run on a blockchain. Pact empowers developers to create robust and high-performance logic for transactions. It facilitates execution of mission-critical business operations quickly and effectively.
 
-![1-pact-smart-contract](assets/beginner-tutorials/welcome-to-pact/1-pact-smart-contract.png)
+![1-pact-smart-contract](./assets/beginner-tutorials/welcome-to-pact/1-pact-smart-contract.png)
 
 Pact is designed with safety in mind. Its design is informed by existing approaches to smart contracts as well as stored procedure languages like SQL and LISP. Pact resembles a general-purpose, Turing-complete language. It includes LISP-like syntax, user functions, modules, and imperative style.
 

--- a/docs/learn-pact/intro.md
+++ b/docs/learn-pact/intro.md
@@ -20,7 +20,7 @@ Pact Developer Tutorials offer the training needed to learn the Pact programming
 These free tutorials have no prerequisites. Learn whenever and however you want using the documentation and complimentary videos for each lesson.
 ## Get Started
 
-Start with our [Beginner Tutorial Series](beginner/welcome-to-pact) which covers Pact’s fundamental concepts, followed by real smart contract projects you can deploy to our Testnet.
+Start with our [Beginner Tutorial Series](./beginner/welcome-to-pact) which covers Pact’s fundamental concepts, followed by real smart contract projects you can deploy to our Testnet.
 ## Connect with our community
 
 - Join the [Discord Channel](https://discord.gg/Z2fq23YJgg) for community discussion


### PR DESCRIPTION
When I visited https://docs.kadena.io this morning, the first link I clicked resulted in a 404 (https://docs.kadena.io/build/resources/useful-tools). So I figured it would be useful to add a broken link checker.

Not sure if GitHub Actions are appreciated here at all? We could consider such pipeline runs as "useful warnings" or go all the way and not accept PRs until the lights are green. Goal of this PR is not to actually fix the broken links (also because I simply don't know where they should point to). I do think we should go through them, because there's quite a few it seems.

The regular expressions in the config are not great, but seem to do well enough for now.

You can run or test GitHub Actions locally:

```
brew install act
act -j markdown-link-check
```